### PR TITLE
Subst nil :value prop with empty string to avoid react error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 node_modules
 /.shadow-cljs
 /package-lock.json
+/pom.xml
+/target

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -95,9 +95,12 @@
                                   ;; React Native allows arrays of styles
                                   (into-js-array (map primitive-obj v))
                                   (primitive-obj v)))
-                :value (set-obj o "value" `(if (nil? ~v)
-                                             ""
-                                             ~v))
+                :value (set-obj o "value" #?(:clj `(if (nil? ~v)
+                                                     js/undefined
+                                                     ~v)
+                                             :cljs (if (nil? v)
+                                                     js/undefined
+                                                     v))
                 (set-obj o (camel-case (kw->str k)) v))))
      #?(:clj (list* o)
         :cljs o))))

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -100,7 +100,7 @@
                                                      ~v)
                                              :cljs (if (nil? v)
                                                      js/undefined
-                                                     v))
+                                                     v)))
                 (set-obj o (camel-case (kw->str k)) v))))
      #?(:clj (list* o)
         :cljs o))))

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -95,6 +95,9 @@
                                   ;; React Native allows arrays of styles
                                   (into-js-array (map primitive-obj v))
                                   (primitive-obj v)))
+                :value (set-obj o "value" (if (nil? v)
+                                            ""
+                                            v))
                 (set-obj o (camel-case (kw->str k)) v))))
      #?(:clj (list* o)
         :cljs o))))

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -95,9 +95,9 @@
                                   ;; React Native allows arrays of styles
                                   (into-js-array (map primitive-obj v))
                                   (primitive-obj v)))
-                :value (set-obj o "value" (if (nil? v)
-                                            ""
-                                            v))
+                :value (set-obj o "value" `(if (nil? ~v)
+                                             ""
+                                             ~v))
                 (set-obj o (camel-case (kw->str k)) v))))
      #?(:clj (list* o)
         :cljs o))))


### PR DESCRIPTION
```
react_devtools_backend.js:6 Warning: `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components
```