### PR TITLE
normalize the class prop

### DIFF
--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -75,6 +75,7 @@
 (defn seq-to-class [class]
   (if (sequential? class)
     (->> class
+         (remove nil?)
          (map str)
          (string/join " "))
     class))

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -79,13 +79,6 @@
          (string/join " "))
     class))
 
-(defn clean-class [class]
-  (if (string? class)
-    (-> class
-        (string/replace #"[ \n]+" " ")
-        (string/trim))
-    class))
-
 #?(:clj
    (defn unquote-class
      "Handle the case of (quote '[foo bar])"
@@ -101,8 +94,7 @@
 #?(:clj
    (defn normalize-class [class]
      (-> class
-         unquote-class
-         clean-class)))
+         unquote-class)))
 
 #?(:cljs
    (defn normalize-class [class]
@@ -111,8 +103,7 @@
        class
        (-> class
            seq-to-class
-           str
-           clean-class))))
+           str))))
 
 (defn -native-props
   ([m] #?(:clj (if-let [spread-sym (cond

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -100,7 +100,7 @@
 
 #?(:clj
    (defn normalize-class [class]
-     #p (-> class
+     (-> class
          unquote-class
          clean-class)))
 

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -72,6 +72,24 @@
 (defn merge-obj [o1 o2]
   #?(:cljs (js/Object.assign o1 o2)))
 
+(defn seq-to-class [class]
+  (if (sequential? class)
+    (->> class
+         (map str)
+         (string/join " "))
+    class))
+
+(defn clean-class [class]
+  (if (string? class)
+    (-> class
+        (string/replace #"[ \n]+" " ")
+        (string/trim))
+    class))
+
+(defn normalize-class [class]
+  (-> class
+      seq-to-class
+      clean-class))
 
 (defn -native-props
   ([m] #?(:clj (if-let [spread-sym (cond
@@ -88,7 +106,7 @@
                   k (key entry)
                   v (val entry)]
               (case k
-                :class (set-obj o "className" v)
+                :class (set-obj o "className" (normalize-class v))
                 :for (set-obj o "htmlFor" v)
                 :style (set-obj o "style"
                                 (if (vector? v)

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -86,10 +86,30 @@
         (string/trim))
     class))
 
-(defn normalize-class [class]
-  (-> class
-      seq-to-class
-      clean-class))
+#?(:clj
+   (defn unquote-class
+     "Handle the case of (quote '[foo bar])"
+     [class]
+     (if (and (list? class)
+              (= (first class) 'quote))
+       (-> class
+           second
+           seq-to-class
+           str)
+       class)))
+
+#?(:clj
+   (defn normalize-class [class]
+     #p (-> class
+         unquote-class
+         clean-class)))
+
+#?(:cljs
+   (defn normalize-class [class]
+     (-> class
+         seq-to-class
+         str
+         clean-class)))
 
 (defn -native-props
   ([m] #?(:clj (if-let [spread-sym (cond

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -106,10 +106,13 @@
 
 #?(:cljs
    (defn normalize-class [class]
-     (-> class
-         seq-to-class
-         str
-         clean-class)))
+     (if (string? class)
+       ;; quick path
+       class
+       (-> class
+           seq-to-class
+           str
+           clean-class))))
 
 (defn -native-props
   ([m] #?(:clj (if-let [spread-sym (cond

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -84,13 +84,19 @@
    (defn unquote-class
      "Handle the case of (quote '[foo bar])"
      [class]
-     (if (and (list? class)
-              (= (first class) 'quote))
+     (cond
+       (string? class)
+       class
+
+       (and (list? class)
+            (= (first class) 'quote))
        (-> class
            second
            seq-to-class
            str)
-       class)))
+
+       :default
+       `(normalize-class ~class))))
 
 #?(:clj
    (defn normalize-class [class]

--- a/test/helix/impl/props_test.cljc
+++ b/test/helix/impl/props_test.cljc
@@ -132,4 +132,7 @@
        (t/is (= (impl/normalize-class 'foo)
                 "foo"))
        (t/is (= (impl/normalize-class '[foo bar])
-                "foo bar")))))
+                "foo bar")))
+     (t/testing "runtime - nil shall be filtered out"
+       (t/is (= (impl/normalize-class ["foo" nil])
+                "foo")))))

--- a/test/helix/impl/props_test.cljc
+++ b/test/helix/impl/props_test.cljc
@@ -112,3 +112,20 @@
                                   :b :extra-b}]
                  (impl/props {:foo-bar :a :b :b :c :c :d :d & extra-props}))
                #js {:foo-bar :extra-foo-bar :b :extra-b :c :c :d :d}))))
+
+
+(t/deftest test-normalize-class
+  (t/testing "support seqs as :class value"
+    (t/is (= (impl/normalize-class '[foo bar])
+             "foo bar"))
+    (t/is (= (impl/normalize-class '(foo bar))
+             "foo bar"))
+    (t/is (= (impl/normalize-class ["foo" "bar"])
+             "foo bar")))
+  (t/testing "normalize string values"
+    (t/is (= (impl/normalize-class "foo bar ")
+             "foo bar"))
+    (t/is (= (impl/normalize-class "foo
+bar
+ barz")
+             "foo bar barz"))))

--- a/test/helix/impl/props_test.cljc
+++ b/test/helix/impl/props_test.cljc
@@ -117,22 +117,27 @@
 (t/deftest test-normalize-class
   #?(:clj
      (do
-       (t/testing "macro expansion - normal value shall be kept as-is"
-         (t/is (= (impl/normalize-class 'foo)
-                  'foo))
-         (t/is (= (impl/normalize-class '[foo bar])
-                  '[foo bar])))
+       (t/testing "macro expansion - string value shall be kept as is"
+         (t/is (= (impl/normalize-class "foo")
+                  "foo")))
        (t/testing "macro expansion - quoted forms shall be converted to string"
          (t/is (= (impl/normalize-class (quote '[foo bar]))
                   "foo bar"))
          (t/is (= (impl/normalize-class (quote 'bar))
-                  "bar")))))
+                  "bar")))
+       (t/testing "macro expansion - other value shall be passed to runtime check"
+         (t/is (= (impl/normalize-class 'foo)
+                  '(helix.impl.props/normalize-class foo)))
+         (t/is (= (impl/normalize-class '[foo bar])
+                  '(helix.impl.props/normalize-class [foo bar])))
+         (t/is (= (impl/normalize-class '(vector foo bar))
+                  '(helix.impl.props/normalize-class (vector foo bar)))))))
   #?(:cljs
-     (t/testing "runtime - all shall be converted to string"
-       (t/is (= (impl/normalize-class 'foo)
-                "foo"))
-       (t/is (= (impl/normalize-class '[foo bar])
-                "foo bar")))
-     (t/testing "runtime - nil shall be filtered out"
-       (t/is (= (impl/normalize-class ["foo" nil])
-                "foo")))))
+     (do (t/testing "runtime - all shall be converted to string"
+           (t/is (= (impl/normalize-class 'foo)
+                    "foo"))
+           (t/is (= (impl/normalize-class '[foo bar])
+                    "foo bar")))
+         (t/testing "runtime - nil shall be filtered out"
+           (t/is (= (impl/normalize-class ["foo" nil])
+                    "foo"))))))

--- a/test/helix/impl/props_test.cljc
+++ b/test/helix/impl/props_test.cljc
@@ -115,17 +115,21 @@
 
 
 (t/deftest test-normalize-class
-  (t/testing "support seqs as :class value"
-    (t/is (= (impl/normalize-class '[foo bar])
-             "foo bar"))
-    (t/is (= (impl/normalize-class '(foo bar))
-             "foo bar"))
-    (t/is (= (impl/normalize-class ["foo" "bar"])
-             "foo bar")))
-  (t/testing "normalize string values"
-    (t/is (= (impl/normalize-class "foo bar ")
-             "foo bar"))
-    (t/is (= (impl/normalize-class "foo
-bar
- barz")
-             "foo bar barz"))))
+  #?(:clj
+     (do
+       (t/testing "macro expansion - normal value shall be kept as-is"
+         (t/is (= (impl/normalize-class 'foo)
+                  'foo))
+         (t/is (= (impl/normalize-class '[foo bar])
+                  '[foo bar])))
+       (t/testing "macro expansion - quoted forms shall be converted to string"
+         (t/is (= (impl/normalize-class (quote '[foo bar]))
+                  "foo bar"))
+         (t/is (= (impl/normalize-class (quote 'bar))
+                  "bar")))))
+  #?(:cljs
+     (t/testing "runtime - all shall be converted to string"
+       (t/is (= (impl/normalize-class 'foo)
+                "foo"))
+       (t/is (= (impl/normalize-class '[foo bar])
+                "foo bar")))))


### PR DESCRIPTION
To support specifying :class with vectors/lists of symbols. This could make it easier to construct class names conditionally. 

```clojure
{:class (cond-> '[foo bar]
     (some-test?)
     (conj 'barz)}
```

And normalize the class string:

```
{:class "foo bar
baz"}

;; becomes
{:class "foo bar baz"}
```
This could be handy when writing multiline string and still control the 80-chars line limit when there are lots of classes. It's very common when using functional frameworks like [tachyons](https://tachyons.io/).

![tachyons](https://user-images.githubusercontent.com/30067222/80571327-0201f480-8a2f-11ea-8741-5f12d51b04aa.png)

This happens at macro expansion, so no runtime overhead is added.