### PR TITLE
Spread JS obj

### DIFF
--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -80,7 +80,10 @@
                  `(merge-obj ~(-native-props (dissoc m spread-sym) (primitive-obj))
                              (-native-props ~(get m spread-sym)))
                  (-native-props m (primitive-obj)))
-          :cljs (-native-props m (primitive-obj))))
+          :cljs (if (map? m)
+                  (-native-props m (primitive-obj))
+                  ;; assume JS obj
+                  m)))
   ([m o]
    (if (seq m)
      (recur (rest m)
@@ -115,12 +118,15 @@
 
 
 (defn -props
-  ([m] (if-let [spread-sym (cond
-                             (contains? m '&) '&
-                             (contains? m :&) :&)]
-         `(merge-obj ~(-props (dissoc m spread-sym) (primitive-obj))
-                     (-props ~(get m spread-sym)))
-         (-props m (primitive-obj))))
+  ([m] #?(:clj (if-let [spread-sym (cond
+                                     (contains? m '&) '&
+                                     (contains? m :&) :&)]
+                 `(merge-obj ~(-props (dissoc m spread-sym) (primitive-obj))
+                             (-props ~(get m spread-sym)))
+                 (-props m (primitive-obj)))
+          :cljs (if (map? m)
+                  (-props m (primitive-obj))
+                  m)))
   ([m o]
    (if (seq m)
      (recur (rest m)

--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -70,7 +70,8 @@
 
 
 (defn merge-obj [o1 o2]
-  #?(:cljs (js/Object.assign o1 o2)))
+  #?(:cljs (doto o1
+             (gobj/extend o2))))
 
 
 (defn -native-props

--- a/test/helix/impl/props_test.cljc
+++ b/test/helix/impl/props_test.cljc
@@ -59,6 +59,10 @@
                                  (cljs.core/js-obj "asdf" (helix.impl.props/->js ~'jkl))))
                  :cljs #js {:style #js [#js {:color "blue"} #js {:asdf "jkl"}]}))
           "Native props with nested literal vector style"))
+  #?(:cljs (t/testing "JS object"
+             (t/is (let [obj #js {:a 1 :b 2 :fooBar #js {:baz "jkl"}}]
+                     (eq (impl/-native-props obj)
+                         obj)))))
   #?(:clj (t/testing "Spread props"
             (t/is (eq (impl/-native-props '{:a 1 :b 2 & foo})
                       `(impl/merge-obj (cljs.core/js-obj "a" 1 "b" 2)
@@ -89,7 +93,10 @@
                #js {:fooBar :extra-foo-bar :b :extra-b :c :c :d :d}))
      (t/is (eq (let [dynamic-style {:color "blue"}]
                  (impl/native-props {:style dynamic-style}))
-               #js {:style #js {:color "blue"}}))))
+               #js {:style #js {:color "blue"}}))
+     (t/is (eq (impl/native-props {:foo "bar"
+                                   & #js {:baz "asdf"}})
+               #js {:foo "bar" :baz "asdf"}))))
 
 
 #?(:cljs
@@ -111,4 +118,7 @@
      (t/is (eq (let [extra-props {:foo-bar :extra-foo-bar
                                   :b :extra-b}]
                  (impl/props {:foo-bar :a :b :b :c :c :d :d & extra-props}))
-               #js {:foo-bar :extra-foo-bar :b :extra-b :c :c :d :d}))))
+               #js {:foo-bar :extra-foo-bar :b :extra-b :c :c :d :d}))
+     (t/is (eq (impl/props {:foo "bar"
+                                   & #js {:baz "asdf"}})
+               #js {:foo "bar" :baz "asdf"}))))


### PR DESCRIPTION
This PR implements the ability to use spread props with JS objects. This way:

```clojure
(let [dynamic-obj #js {:baz "jkl"}]
  ($ component {:foo "bar" & dynamic-obj}))
```

Works just the same as spreading a map today.

This is especially nice for using libraries that pass you props using either a hook or a render-as-child/prop pattern:

```clojure
($ SomeLib
  (fn [props]
    (d/div {& props} "hi")))
```