### PR TITLE
Flatten class normalization logic

### DIFF
--- a/src/helix/impl/props.cljc
+++ b/src/helix/impl/props.cljc
@@ -73,44 +73,42 @@
   #?(:cljs (js/Object.assign o1 o2)))
 
 (defn seq-to-class [class]
-  (if (sequential? class)
-    (->> class
-         (remove nil?)
-         (map str)
-         (string/join " "))
-    class))
+  (->> class
+       (remove nil?)
+       (map str)
+       (string/join " ")))
 
 #?(:clj
    (defn unquote-class
      "Handle the case of (quote '[foo bar])"
      [class]
+     (if (sequential? class)
+       (seq-to-class class)
+       (str class))))
+
+#?(:clj
+   (defn normalize-class [class]
      (cond
        (string? class)
        class
 
        (and (list? class)
             (= (first class) 'quote))
-       (-> class
-           second
-           seq-to-class
-           str)
+       (unquote-class (second class))
 
        :default
        `(normalize-class ~class))))
 
-#?(:clj
-   (defn normalize-class [class]
-     (-> class
-         unquote-class)))
-
 #?(:cljs
    (defn normalize-class [class]
-     (if (string? class)
+     (cond
        ;; quick path
-       class
-       (-> class
-           seq-to-class
-           str))))
+       (string? class) class
+
+       (sequential? class) (seq-to-class class)
+
+       ;; not a string or sequential, stringify it
+       true (str class))))
 
 (defn -native-props
   ([m] #?(:clj (if-let [spread-sym (cond

--- a/test/helix/impl/props_test.cljc
+++ b/test/helix/impl/props_test.cljc
@@ -118,20 +118,20 @@
   #?(:clj
      (do
        (t/testing "macro expansion - string value shall be kept as is"
-         (t/is (= (impl/normalize-class "foo")
-                  "foo")))
+         (t/is (= "foo"
+                  (impl/normalize-class "foo"))))
        (t/testing "macro expansion - quoted forms shall be converted to string"
-         (t/is (= (impl/normalize-class (quote '[foo bar]))
-                  "foo bar"))
-         (t/is (= (impl/normalize-class (quote 'bar))
-                  "bar")))
+         (t/is (= "foo bar"
+                  (impl/normalize-class (quote '[foo bar]))))
+         (t/is (= "bar"
+                  (impl/normalize-class (quote 'bar)))))
        (t/testing "macro expansion - other value shall be passed to runtime check"
-         (t/is (= (impl/normalize-class 'foo)
-                  '(helix.impl.props/normalize-class foo)))
-         (t/is (= (impl/normalize-class '[foo bar])
-                  '(helix.impl.props/normalize-class [foo bar])))
-         (t/is (= (impl/normalize-class '(vector foo bar))
-                  '(helix.impl.props/normalize-class (vector foo bar)))))))
+         (t/is (= '(helix.impl.props/normalize-class foo)
+                  (impl/normalize-class 'foo)))
+         (t/is (= '(helix.impl.props/normalize-class [foo bar])
+                  (impl/normalize-class '[foo bar])))
+         (t/is (= '(helix.impl.props/normalize-class (vector foo bar))
+                  (impl/normalize-class '(vector foo bar)))))))
   #?(:cljs
      (do (t/testing "runtime - all shall be converted to string"
            (t/is (= (impl/normalize-class 'foo)


### PR DESCRIPTION
A small refactoring of class normalization to flatten the conditionals into one `cond` inside `normalize-class`.