### PR TITLE
Use goog.module for JavaScript

### DIFF
--- a/src/helix/core.cljs
+++ b/src/helix/core.cljs
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [type])
   (:require [goog.object :as gobj]
             [helix.impl.props :as impl.props]
-            ["./impl/class.js" :as helix.class]
+            [helix.impl.class :as helix.class]
             [cljs-bean.core :as bean]
             ["react" :as react])
   (:require-macros [helix.core]))

--- a/src/helix/impl/class.js
+++ b/src/helix/impl/class.js
@@ -1,4 +1,6 @@
-export function createComponent(superclass, spec, statics) {
+goog.module('helix.impl.class');
+
+function createComponent(superclass, spec, statics) {
   let component = class HelixComponent extends superclass {
     constructor(props) {
       super(props);
@@ -30,3 +32,5 @@ export function createComponent(superclass, spec, statics) {
 
   return component;
 }
+
+exports.createComponent = createComponent;


### PR DESCRIPTION
This makes it work with ClojureScript versions 1.10.741+ which updated
Google Closure.

I've tested this still works with Shadow Cljs

Fix #52
