### PR TITLE
Metadata annotations for optimizations

### DIFF
--- a/dev/workshop/core.cljs
+++ b/dev/workshop/core.cljs
@@ -212,10 +212,14 @@
 (defnc use-memo-metadata
   [{:keys [foo]}]
   {:helix/features {:metadata-optimizations true}}
-  (let [foobar ^:memo (str foo "bar")
-        example1 (hooks/use-memo :auto-deps (str foo "bar"))
-        example2 (hooks/use-memo [foo] (str foo "bar"))]
-    ^:memo (d/div foobar)))
+  (let [foobar ^:memo (vector foo "bar")
+        first-foobar (hooks/use-ref foobar)
+        [count set-count] (hooks/use-state 0)]
+    (d/div
+     (str (identical? foobar @first-foobar))
+     (d/br)
+     count
+     (d/button {:on-click #(set-count inc)} "render"))))
 
 
 (dc/defcard use-memo-metadata-card

--- a/dev/workshop/core.cljs
+++ b/dev/workshop/core.cljs
@@ -208,6 +208,28 @@
                                  (d/div (.-count (.-state this))))}
                           nil))
 
+
+#_(js/console.log
+ (macroexpand '(defnc use-memo-metadata
+  [{:keys [foo]}]
+  {:helix/features {:metadata-optimizations true}}
+  (let [foobar ^:memo (str foo "bar")]
+    ^:memo (d/div foobar))) ))
+
+
+(defnc use-memo-metadata
+  [{:keys [foo]}]
+  {:helix/features {:metadata-optimizations true}}
+  (let [foobar ^:memo (str foo "bar")
+        example1 (hooks/use-memo :auto-deps (str foo "bar"))
+        example2 (hooks/use-memo [foo] (str foo "bar"))]
+    ^:memo (d/div foobar)))
+
+
+(dc/defcard use-memo-metadata-card
+  ($ use-memo-metadata {:foo "foo"}))
+
+
 (helix/defcomponent ClassComponent
   (render [this props state]
     (d/div "hi")))

--- a/dev/workshop/core.cljs
+++ b/dev/workshop/core.cljs
@@ -209,14 +209,6 @@
                           nil))
 
 
-#_(js/console.log
- (macroexpand '(defnc use-memo-metadata
-  [{:keys [foo]}]
-  {:helix/features {:metadata-optimizations true}}
-  (let [foobar ^:memo (str foo "bar")]
-    ^:memo (d/div foobar))) ))
-
-
 (defnc use-memo-metadata
   [{:keys [foo]}]
   {:helix/features {:metadata-optimizations true}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -18,7 +18,8 @@
                          :depends-on #{:shared}}
                   :refresh {:entries [refresh-example]
                             :depends-on #{:shared}}}
-        :compiler-options {:devcards true}
+        :compiler-options {:devcards true
+                           :output-feature-set :es6}
         :devtools {:http-root    "public/dev"
                    :http-port    8700
                    :preloads     [devtools.preload]}}

--- a/src/helix/core.clj
+++ b/src/helix/core.clj
@@ -89,6 +89,21 @@
          ~@body))))
 
 
+(def meta->form
+  {:memo (fn [form deps]
+           `(helix.hooks/use-memo
+             ~(if (coll? deps)
+                deps
+                :auto-deps)
+             ~form))
+   :callback (fn [form deps]
+               `(helix.hooks/use-callback
+                 ~(if (coll? deps)
+                    deps
+                    :auto-deps)
+                 ~form))})
+
+
 (defmacro defnc
   "Creates a new functional React component. Used like:
 
@@ -127,10 +142,6 @@
         opts (if opts-map?
                (first body)
                {})
-        body (if opts-map?
-               (rest body)
-               body)
-        hooks (hana/find-hooks body)
         sig-sym (gensym "sig")
         fully-qualified-name (str *ns* "/" display-name)
         feature-flags (:helix/features opts)
@@ -138,7 +149,16 @@
         ;; feature flags
         flag-fast-refresh? (:fast-refresh feature-flags)
         flag-check-invalid-hooks-usage? (:check-invalid-hooks-usage feature-flags)
-        flag-define-factory? (:define-factory feature-flags)]
+        flag-define-factory? (:define-factory feature-flags)
+        flag-metadata-optimizations (:metadata-optimizations feature-flags)
+
+
+        body (cond-> body
+               opts-map? (rest)
+               flag-metadata-optimizations (hana/map-forms-with-meta meta->form))
+
+        hooks (hana/find-hooks body)]
+
     (when flag-check-invalid-hooks-usage?
       (when-some [invalid-hooks (->> (map hana/invalid-hooks-usage body)
                                      (flatten)
@@ -148,6 +168,7 @@
           (hana/warn hana/warning-invalid-hooks-usage
                      &env
                      invalid-hook))))
+
     `(do ~(when flag-fast-refresh?
             `(if ^boolean goog/DEBUG
                (def ~sig-sym (signature!))))
@@ -164,7 +185,7 @@
                               `(if ^boolean goog/DEBUG
                                  (when ~sig-sym
                                    (~sig-sym))))
-                                         body))
+                            body))
                (cond->
                  (true? ^boolean goog/DEBUG)
                  (doto (goog.object/set "displayName" ~fully-qualified-name)))

--- a/test/helix/core_test.cljs
+++ b/test/helix/core_test.cljs
@@ -1,0 +1,19 @@
+(ns helix.core-test
+  (:require
+    [cljs.test :as t :include-macros true]
+    [helix.core :as helix :refer (defnc $)]))
+
+
+(t/deftest metadata-optimization-expansion
+  (t/is (->> (macroexpand
+              '(helix/defnc metadata-optimization
+                 []
+                 {:helix/features {:metadata-optimizations true}}
+                 (let [foo "foo"
+                       bar ^{:memo [foo]} (str foo "bar")]
+                   ^:memo ($ "div" "asdf"))))
+             (tree-seq #(and (seqable? %) (not (string? %))) seq)
+             ;; this take is here because I accidentally blew this up too many
+             ;; times with an infinite loop
+             (take 100)
+             (some #(= % '(helix.hooks/use-memo [foo] (str foo "bar")))))))


### PR DESCRIPTION
This PR implements a new feature in the Helix component analyzer/compiler: the ability to annotate expressions with `:memo` and `:callback` metadata and have them wrapped in `use-memo` or `use-callback`.

By default, annotating an expression with `^:memo` or `^:callback` will automatically infer the dependencies from the local context. E.g.:

```clojure
(let [foo "foo"
      foobar ^:memo (str foo "bar)]
  ,,,)
```

Will be emitted as

```clojure
(let [foo "foo"
      foobar (helix.hooks/use-memo [foo] (str foo "bar"))]
  ,,,)
```

You can override this by passing in a vector of dependencies into the annotating:

```clojure
(let [foo "foo"
      foobar ^{:memo :once} (str foo "bar)]
  ,,,)
```

Will emit
```clojure
```clojure
(let [foo "foo"
      foobar (helix.hooks/use-memo :once (str foo "bar"))]
  ,,,)
```