### PR TITLE
Add docstring support to custom defnc

### DIFF
--- a/docs/pro-tips.md
+++ b/docs/pro-tips.md
@@ -101,7 +101,10 @@ use it.
 
 
 (defmacro defnc [type params & body]
-  (let [opts? (map? (first body)) ;; whether an opts map was passed in
+  (let [[docstring params body] (if (string? params)
+                                  [params (first body) (rest body)]
+                                  [nil params body])
+        opts? (map? (first body)) ;; whether an opts map was passed in
         opts (if opts?
                (first body)
                {})
@@ -110,7 +113,7 @@ use it.
                body)
         ;; feature flags to enable by default
         default-opts {:helix/features {:fast-refresh true}}]
-    `(helix.core/defnc ~type ~params
+    `(helix.core/defnc ~type ~@(when docstring [docstring]) ~params
        ;; we use `merge` here to allow indidivual consumers to override feature
        ;; flags in special cases
        ~(merge default-opts opts)


### PR DESCRIPTION
Simple change, but we noticed we couldn't docstring in our project.