### PR TITLE
dont log result of performReactRefresh

### DIFF
--- a/src/helix/experimental/refresh.cljs
+++ b/src/helix/experimental/refresh.cljs
@@ -17,4 +17,4 @@
 
 (defn refresh!
   []
-  (js/console.log (refresh/performReactRefresh)))
+  (refresh/performReactRefresh))


### PR DESCRIPTION
I'd like to suggest that by default we don't log the result of performReactRefresh to the console.  In my app, this is sometimes 20-30 lines (with wrapping) in the terminal, and it clutters up the logs.

Since `helix.experimental.refresh/refresh!` is typically called by user code anyway, it would be easy for users who want to log this to do it themselves.